### PR TITLE
Export helpers

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -24,9 +24,33 @@ exports.number = number;
 exports.obfuscated = obfuscated;
 exports.onSelf = onSelf;
 exports.oneOf = oneOf;
+Object.defineProperty(exports, "parseExpect", {
+  enumerable: true,
+  get: function get() {
+    return _testHelper.parseExpect;
+  }
+});
+Object.defineProperty(exports, "parseFailure", {
+  enumerable: true,
+  get: function get() {
+    return _testHelper.parseFailure;
+  }
+});
+Object.defineProperty(exports, "parseSuccess", {
+  enumerable: true,
+  get: function get() {
+    return _testHelper.parseSuccess;
+  }
+});
 exports.pure = pure;
 exports.record = record;
 exports.rounded = rounded;
+Object.defineProperty(exports, "saferStringify", {
+  enumerable: true,
+  get: function get() {
+    return _formatting2.saferStringify;
+  }
+});
 exports.string = string;
 exports.stringEnum = stringEnum;
 exports.stringInt = stringInt;
@@ -49,6 +73,10 @@ var _path = _interopRequireDefault(require("./path.js"));
 var _either = _interopRequireDefault(require("./either.js"));
 
 var _formatting = require("./formatting.js");
+
+var _formatting2 = require("./formatting");
+
+var _testHelper = require("./test-helper");
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { "default": obj }; }
 

--- a/dist/index.js.flow
+++ b/dist/index.js.flow
@@ -12,6 +12,9 @@ import {type EitherT} from './either.js'
 import Either from './either.js'
 import {formatError} from './formatting.js'
 
+export {saferStringify} from './formatting'
+export {parseExpect, parseSuccess, parseFailure} from './test-helper'
+
 // Recoverable errors mean we can try another parser in
 // firstOf. Fatal errors short circuit any operation.
 type LevelT = 'recoverable' | 'fatal'

--- a/package.json
+++ b/package.json
@@ -1,32 +1,32 @@
 {
-    "name": "@freckle/parser-js",
-    "version": "1.0.0",
-    "description": "One that parses",
-    "main": "./dist/index.js",
-    "repository": "https://github.com/freckle/parser-js.git",
-    "author": "Freckle",
-    "license": "MIT",
-    "scripts": {
-        "build": "babel src -d dist --ignore \"src/**/*.test.js\" &&flow-copy-source -i \"src/**/*.test.js\" src dist",
-        "test": "jest",
-        "flow": "flow",
-        "format": "prettier --write 'src/**/*.js'",
-        "check-git-clean": "./check-git-clean.sh"
-    },
-    "dependencies": {
-        "@freckle/exhaustive-js": "https://github.com/freckle/exhaustive-js.git#v1.0.0",
-        "@freckle/non-empty-js": "https://github.com/freckle/non-empty-js.git#v1.0.1",
-        "lodash": "4.17.21",
-        "moment-timezone": "0.5.33"
-    },
-    "devDependencies": {
-        "@babel/cli": "^7.17.0",
-        "@babel/core": "^7.17.0",
-        "@babel/preset-env": "^7.16.11",
-        "@babel/preset-flow": "^7.16.7",
-        "flow-bin": "^0.171.0",
-        "flow-copy-source": "2.0.9",
-        "jest": "^27.4.7",
-        "prettier": "^2.5.1"
-    }
+  "name": "@freckle/parser-js",
+  "version": "1.0.0",
+  "description": "One that parses",
+  "main": "./dist/index.js",
+  "repository": "https://github.com/freckle/parser-js.git",
+  "author": "Freckle",
+  "license": "MIT",
+  "scripts": {
+    "build": "babel src -d dist --ignore \"src/**/*.test.js\" &&flow-copy-source -i \"src/**/*.test.js\" src dist",
+    "test": "jest",
+    "flow": "flow",
+    "format": "prettier --write 'src/**/*.js'",
+    "check-git-clean": "./check-git-clean.sh"
+  },
+  "dependencies": {
+    "@freckle/exhaustive-js": "https://github.com/freckle/exhaustive-js.git#v1.0.0",
+    "@freckle/non-empty-js": "https://github.com/freckle/non-empty-js.git#v1.0.1",
+    "lodash": "4.17.21",
+    "moment-timezone": "0.5.33"
+  },
+  "devDependencies": {
+    "@babel/cli": "^7.17.0",
+    "@babel/core": "^7.17.0",
+    "@babel/preset-env": "^7.16.11",
+    "@babel/preset-flow": "^7.16.7",
+    "flow-bin": "^0.171.0",
+    "flow-copy-source": "2.0.9",
+    "jest": "^27.4.7",
+    "prettier": "^2.5.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@freckle/parser-js",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "One that parses",
   "main": "./dist/index.js",
   "repository": "https://github.com/freckle/parser-js.git",

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,9 @@ import {type EitherT} from './either.js'
 import Either from './either.js'
 import {formatError} from './formatting.js'
 
+export {saferStringify} from './formatting'
+export {parseExpect, parseSuccess, parseFailure} from './test-helper'
+
 // Recoverable errors mean we can try another parser in
 // firstOf. Fatal errors short circuit any operation.
 type LevelT = 'recoverable' | 'fatal'


### PR DESCRIPTION
Consuming projects need to be able to import `saferStringify` and test helpers.